### PR TITLE
Fix undefined behavior in UDL macro

### DIFF
--- a/fmt/format.h
+++ b/fmt/format.h
@@ -266,11 +266,14 @@ typedef __int64          intmax_t;
 // makes the fmt::literals implementation easier. However, an explicit check
 // for variadic templates is added here just in case.
 // For Intel's compiler both it and the system gcc/msc must support UDLs.
-# define FMT_USE_USER_DEFINED_LITERALS \
-   FMT_USE_VARIADIC_TEMPLATES && FMT_USE_RVALUE_REFERENCES && \
+# if FMT_USE_VARIADIC_TEMPLATES && FMT_USE_RVALUE_REFERENCES && \
    (FMT_HAS_FEATURE(cxx_user_literals) || \
      (FMT_GCC_VERSION >= 407 && FMT_HAS_GXX_CXX11) || FMT_MSC_VER >= 1900) && \
    (!defined(FMT_ICC_VERSION) || FMT_ICC_VERSION >= 1500)
+#  define FMT_USE_USER_DEFINED_LITERALS 1
+# else
+#  define FMT_USE_USER_DEFINED_LITERALS 0
+# endif
 #endif
 
 #ifndef FMT_USE_EXTERN_TEMPLATES


### PR DESCRIPTION
`FMT_USE_USER_DEFINED_LITERALS` macro expands to `defined()` which is undefined behavior.